### PR TITLE
Export query implementation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -70,6 +70,7 @@ var login = function(client, username, password, callback) {
   };
   client.runSoapMethod('login', credentials, {requestOptions: requestOptions}, function(err, resp) {
     if (err) return callback(err);
+    client.session = resp.Session;
     setSessionHeader(client._client, resp.Session);
     if (callback) callback(null, resp);
   });

--- a/lib/common.js
+++ b/lib/common.js
@@ -27,7 +27,7 @@ function chunk(stuff, size) {
     result.push(stuff.slice(start, end));
     start = end;
   }
-  console.log(result);
+  log.debug({chunkResult: result}, 'common.chunk');
   return result;
 }
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,7 +1,8 @@
-var client  = require('./client');
-var objects = require('./objects');
-var log     = require('./logger');
-var query   = require('./query');
+var client      = require('./client');
+var objects     = require('./objects');
+var log         = require('./logger');
+var query       = require('./query');
+var exportQuery = require('./export_query');
 
 function connect(config, cb) {
   log.create(config.logger);
@@ -11,6 +12,7 @@ function connect(config, cb) {
     z.client = client;
     objects(client, z);
     query(z);
+    exportQuery(client, config, z);
     return cb(null, z);
   })
 }

--- a/lib/export_query.js
+++ b/lib/export_query.js
@@ -126,8 +126,8 @@ function attachExportMethods(client, config, xmasTree) {
     }
 
     xmasTree.export.create(exportObject, function (err, result) {
-      if (err) {
-        return cb(err);
+      if (err || !result[0].Success) {
+        return cb(err || result[0].Errors);
       }
       var exportId = result[0].Id;
       watchExportProgress(xmasTree, watcherConfig, exportId, function (err, fileId) {

--- a/lib/export_query.js
+++ b/lib/export_query.js
@@ -2,6 +2,7 @@ var csvParser = require('csv-parser');
 var request = require('request');
 var es = require('event-stream');
 var log = require('./logger');
+var extend = require('util')._extend;
 
 function fetchExport(client, config, fileId) {
   var url = buildFileURL(client._client.lastEndpoint, fileId);
@@ -21,28 +22,31 @@ function fetchExport(client, config, fileId) {
     .pipe(csvParser());
 }
 
-function watchExportProgress(z, exportId, callback) {
+function watchExportProgress(z, watcherConfig, exportId, callback) {
   var query = "SELECT status, statusReason, fileId, query, size FROM Export WHERE Id='" + exportId + "'";
-  var interval = 5000;
-  var maxLimit = 200;
-  var maxAttempts = 200;
+  var settings = extend({
+    interval: 5000,
+    maxAttempts: 200
+  }, watcherConfig || {});
+  var maxLimit = settings.maxAttempts;
+
   checkExportProgress();
 
   function checkExportProgress() {
-    log.debug('Waiting for export.. attempt  -> ', maxLimit - maxAttempts);
+    log.debug('Waiting for export.. attempt  -> ', maxLimit - settings.maxAttempts);
     z.query(query, function(err, records) {
       //if (err) return callback(err);
       if (err) {
         log.warn('Zuora Export Warning: zuora_query() error: %s', err);
-        setTimeout(checkExportProgress, interval);
+        setTimeout(checkExportProgress, settings.interval);
         return;
       }
       var record = records[0];
       switch (record.Status) {
         case 'Pending':
         case 'Processing':
-          if (--maxAttempts > 0) {
-            setTimeout(checkExportProgress, interval);
+          if (--settings.maxAttempts > 0) {
+            setTimeout(checkExportProgress, settings.interval);
           } else {
             callback(new Error('Zuora Export Error: Retry timeout'));
           }
@@ -83,8 +87,13 @@ function attachExportMethods(client, config, xmasTree) {
   xmasTree.export.asArray = exportAsArray;
 
   // Buffer the full export as an array
-  function exportAsArray(exportConfig, cb) {
-    execute(exportConfig, function (err, stream) {
+  function exportAsArray(exportObject, watcherConfig, cb) {
+    if (typeof watcherConfig === 'function') {
+      cb = watcherConfig;
+      watcherConfig = {};
+    }
+
+    execute(exportObject, watcherConfig, function (err, stream) {
       if (err) {
         return cb(err);
       }
@@ -98,25 +107,30 @@ function attachExportMethods(client, config, xmasTree) {
     });
   }
 
-  function execute(exportConfig, cb) {
-    if (typeof exportConfig === 'string') {
-      exportConfig = {
+  function execute(exportObject, watcherConfig, cb) {
+    if (typeof watcherConfig === 'function') {
+      cb = watcherConfig;
+      watcherConfig = {};
+    }
+
+    if (typeof exportObject === 'string') {
+      exportObject = {
         format: 'csv',
         name: 'node_zuora export',
-        query: exportConfig
+        query: exportObject
       };
     }
     // Only csv exports are supported right now
-    if (exportConfig.format !== 'csv') {
+    if (exportObject.format !== 'csv') {
       cb(new Error('Only csv formatting is supported'));
     }
 
-    xmasTree.export.create(exportConfig, function (err, result) {
+    xmasTree.export.create(exportObject, function (err, result) {
       if (err) {
         return cb(err);
       }
       var exportId = result[0].Id;
-      watchExportProgress(xmasTree, exportId, function (err, fileId) {
+      watchExportProgress(xmasTree, watcherConfig, exportId, function (err, fileId) {
         if (err) {
           return cb(err);
         }

--- a/lib/export_query.js
+++ b/lib/export_query.js
@@ -1,139 +1,171 @@
-var csvParser = require('./csvParser');
+var csvParser = require('csv-parser');
+var request = require('request');
+var es = require('event-stream');
+var log = require('./logger');
 
-  function fetchExport(exportId, fileId, callback) {
-    var url = buildFileURL(fileId);
-    var options = {
-      method: 'GET',
-      url: url,
-      auth: {
-        user: config.user,
-        pass: config.password
-      },
-      headers: {
-        'Authorization': 'ZSession ' + client.joyentsession
-      },
-      timeout: 10000
+function fetchExport(client, config, fileId, callback) {
+  var url = buildFileURL(client._client.lastEndpoint, fileId);
+  var options = {
+    method: 'GET',
+    url: url,
+    auth: {
+      user: config.user,
+      pass: config.password
+    },
+    headers: {
+      'Authorization': 'ZSession ' + client.session
+    },
+    timeout: 10000
+  }
+  request(options)
+    .pipe(csvParser())
+    .pipe(es.writeArray(handleResponse))
+
+  function handleResponse(err, array) {
+    if (err) {
+      return callback(err);
     }
-    request(options)
-      .pipe(csvParser())
-      .pipe(es.writeArray(handleResponse))
+    callback(null, {
+      size: array.length,
+      records: array
+    });
+  }
 
-    function handleResponse(err, array) {
-      var values = [];
-      if (err) return callback(err);
-      // convert it so the output looks like the
-      for (var i in array) {
-        var item = array[i];
-        var keys = Object.keys(item);
-        var value = {};
-        for (var j in keys) {
-          var key = keys[j];
-          var indexes = key.split(".");
-          var index = indexes[indexes.length - 1];
-          // Id is always an array
-          if (index == "Id") {
-            var ids = [];
-            ids.push(item[key]);
-            value[index] = ids;
-          } else if (index == "Subscription.Name") {
-            value["SubscriptionNumber"] = item[key]
+  //function handleResponse(err, array) {
+  //  var values = [];
+  //  if (err) return callback(err);
+  //  // convert it so the output looks like the
+  //  for (var i in array) {
+  //    var item = array[i];
+  //    var keys = Object.keys(item);
+  //    var value = {};
+  //    for (var j in keys) {
+  //      var key = keys[j];
+  //      var indexes = key.split(".");
+  //      var index = indexes[indexes.length - 1];
+  //      // Id is always an array
+  //      if (index == "Id") {
+  //        var ids = [];
+  //        ids.push(item[key]);
+  //        value[index] = ids;
+  //      } else if (index == "Subscription.Name") {
+  //        value["SubscriptionNumber"] = item[key]
+  //      } else {
+  //        value[index] = item[key];
+  //      }
+  //      value[key] = item[key];
+  //    }
+  //    values.push(value);
+  //  }
+  //  callback(null, {
+  //    size: array.length,
+  //    records: values
+  //  })
+  //}
+  /*
+  request(options, handleResponse);
+
+  function handleResponse(error, response, body) {
+    //console.log(error);
+    //console.log(response.statusCode);
+    //console.log(body);
+    if (!error && (String(response.statusCode)[0] !== '2')) {
+      error = new Error('Error http statuscode = ' + response.statusCode);
+    }
+    callback(error, body);
+  }
+  */
+}
+
+function watchExportProgress(z, exportId, callback) {
+  var query = "SELECT status, statusReason, fileId, query, size FROM Export WHERE Id='" + exportId + "'";
+  var interval = 5000;
+  var maxLimit = 200;
+  var maxAttempts = 200;
+  checkExportProgress();
+
+  function checkExportProgress() {
+    log.debug('Waiting for export.. attempt  -> ', maxLimit - maxAttempts);
+    z.query(query, function(err, records) {
+      //if (err) return callback(err);
+      if (err) {
+        log.warn('Zuora Export Warning: zuora_query() error: %s', err);
+        setTimeout(checkExportProgress, interval);
+        return;
+      }
+      var record = records[0];
+      switch (record.Status) {
+        case 'Pending':
+        case 'Processing':
+          if (--maxAttempts > 0) {
+            setTimeout(checkExportProgress, interval);
           } else {
-            value[index] = item[key];
+            callback(new Error('Zuora Export Error: Retry timeout'));
           }
-          value[key] = item[key];
-        }
-        values.push(value);
+          break;
+        case 'Completed':
+          callback(null, record.FileId);
+          break;
+        case 'Failed':
+        case 'Canceled':
+          callback(new Error('Zuora Export Error: ' + record.Status + ' ' + record.statusReason));
+          break;
+        default:
+          callback(new Error('Unexpected Export status of ' + record.Status));
       }
-      callback(null, {
-        size: array.length,
-        records: values
-      })
-    }
-    /*
-    request(options, handleResponse);
-
-    function handleResponse(error, response, body) {
-      //console.log(error);
-      //console.log(response.statusCode);
-      //console.log(body);
-      if (!error && (String(response.statusCode)[0] !== '2')) {
-        error = new Error('Error http statuscode = ' + response.statusCode);
-      }
-      callback(error, body);
-    }
-    */
+    })
   }
+}
 
-  function watchExportProgress(exportId, onComplete) {
-    var query = "SELECT status, statusReason, fileId, query, size FROM Export WHERE Id='" + exportId + "'";
-    var zQuery = {
-      'queryString': query
-    };
-    var interval = 5000;
-    var maxLimit = 200;
-    var maxAttempts = 200;
-    checkExportProgress();
+function deleteExport(z, exportId) {
+  z.export.delete([{Id: exportId}], function (err, results) {
+    if (err || !results[0].success) {
+      log.warn('Unable to remove export from zuora: ' + err);
+    }
+  });
+}
 
-    function checkExportProgress() {
-      console.log('Waiting for export.. attempt  -> ', maxLimit - maxAttempts);
-      zuora_query(client, zQuery, function(err, client, resp) {
-        //if (err) return callback(err);
+// example output: https://www.zuora.com/apps/api/file/{{fileId}}
+
+function buildFileURL(endpoint, fileId) {
+  var url = endpoint.split('/');
+  url.length = 4;
+  return url.concat(['api', 'file', fileId]).join('/');
+}
+
+function attachExport(client, config, xmasTree) {
+  xmasTree.export.execute = function (exportConfig, cb) {
+    if (typeof exportConfig === 'string') {
+      exportConfig = {
+        format: 'csv',
+        name: 'node_zuora export',
+        query: exportConfig
+      };
+    }
+    // Only csv exports are supported right now
+    if (exportConfig.format !== 'csv') {
+      cb(new Error('Only csv formatting is supported'));
+    }
+
+    xmasTree.export.create(exportConfig, function (err, result) {
+      if (err) {
+        return cb(err);
+      }
+      var exportId = result[0].Id;
+      watchExportProgress(xmasTree, exportId, function (err, fileId) {
         if (err) {
-          console.log('Zuora Export Warning: zuora_query() error: %s', err);
-          setTimeout(checkExportProgress, interval);
-          return;
+          return cb(err);
         }
-        //console.log(JSON.stringify(resp, undefined, 2));
-        var records = resp.records[0] || resp.records;
-        switch (records.Status) {
-          case 'Pending':
-          case 'Processing':
-            if (--maxAttempts > 0) {
-              setTimeout(checkExportProgress, interval);
-            } else {
-              console.log(resp);
-              callback(new Error('Zuora Export Error: Retry timeout'));
-            }
-            break;
-          case 'Completed':
-            onComplete(records.FileId);
-            break;
-          case 'Failed':
-          case 'Canceled':
-            callback(new Error('Zuora Export Error: ' + records.Status + ' ' + records.statusReason));
-            break;
-          default:
-            callback(new Error('Unexpected Export status of ' + records.Status));
-        }
-      })
-    }
-  }
-
-
-  function cleanupfile(fid, callback) {
-    var values = {
-      type: "export",
-      ids: fid
-    }
-    var zobject = " <zns:delete><zns:type>export</zns:type><zns:ids>" + fid + "</zns:ids></zns:delete>"
-    // console.log("cleanupfile: ",zobject);
-    zuora_delete(client, zobject, function(err, client, results, body) {
-      //console.log("results from cleanupfile:", json.stringify(results, undefined,2));
-
-      if (!err && results[0].success == true) {
-        console.log("removed file from zuora.");
-
-      } else {
-        console.log("unable to remove file from zuora err:", err, "results:", json.stringify(results, undefined, 2));
-      }
-      callback(err);
+        fetchExport(client, config, fileId, function (err, data) {
+          if (err) {
+            return cb(err);
+          }
+          deleteExport(xmasTree, exportId);
+          cb(null, data);
+        });
+      });
     });
   };
+}
 
-  // example output: https://www.zuora.com/apps/api/file/{{fileId}}
-
-  function buildFileURL(fileId) {
-    var url = config.endpoint.split('/');
-    url.length = 4;
-    return url.concat(['api', 'file', fileId]).join('/');
-  }
+module.exports = attachExport;

--- a/lib/export_query.js
+++ b/lib/export_query.js
@@ -3,7 +3,7 @@ var request = require('request');
 var es = require('event-stream');
 var log = require('./logger');
 
-function fetchExport(client, config, fileId, callback) {
+function fetchExport(client, config, fileId) {
   var url = buildFileURL(client._client.lastEndpoint, fileId);
   var options = {
     method: 'GET',
@@ -17,64 +17,8 @@ function fetchExport(client, config, fileId, callback) {
     },
     timeout: 10000
   }
-  request(options)
-    .pipe(csvParser())
-    .pipe(es.writeArray(handleResponse))
-
-  function handleResponse(err, array) {
-    if (err) {
-      return callback(err);
-    }
-    callback(null, {
-      size: array.length,
-      records: array
-    });
-  }
-
-  //function handleResponse(err, array) {
-  //  var values = [];
-  //  if (err) return callback(err);
-  //  // convert it so the output looks like the
-  //  for (var i in array) {
-  //    var item = array[i];
-  //    var keys = Object.keys(item);
-  //    var value = {};
-  //    for (var j in keys) {
-  //      var key = keys[j];
-  //      var indexes = key.split(".");
-  //      var index = indexes[indexes.length - 1];
-  //      // Id is always an array
-  //      if (index == "Id") {
-  //        var ids = [];
-  //        ids.push(item[key]);
-  //        value[index] = ids;
-  //      } else if (index == "Subscription.Name") {
-  //        value["SubscriptionNumber"] = item[key]
-  //      } else {
-  //        value[index] = item[key];
-  //      }
-  //      value[key] = item[key];
-  //    }
-  //    values.push(value);
-  //  }
-  //  callback(null, {
-  //    size: array.length,
-  //    records: values
-  //  })
-  //}
-  /*
-  request(options, handleResponse);
-
-  function handleResponse(error, response, body) {
-    //console.log(error);
-    //console.log(response.statusCode);
-    //console.log(body);
-    if (!error && (String(response.statusCode)[0] !== '2')) {
-      error = new Error('Error http statuscode = ' + response.statusCode);
-    }
-    callback(error, body);
-  }
-  */
+  return request(options)
+    .pipe(csvParser());
 }
 
 function watchExportProgress(z, exportId, callback) {
@@ -133,8 +77,28 @@ function buildFileURL(endpoint, fileId) {
   return url.concat(['api', 'file', fileId]).join('/');
 }
 
-function attachExport(client, config, xmasTree) {
-  xmasTree.export.execute = function (exportConfig, cb) {
+function attachExportMethods(client, config, xmasTree) {
+  // Shorthand methods to execute and retrieve exports
+  xmasTree.export.asStream = execute;
+  xmasTree.export.asArray = exportAsArray;
+
+  // Buffer the full export as an array
+  function exportAsArray(exportConfig, cb) {
+    execute(exportConfig, function (err, stream) {
+      if (err) {
+        return cb(err);
+      }
+
+      stream.pipe(es.writeArray(function (err, array) {
+        if (err) {
+          return cb(err);
+        }
+        cb(null, array);
+      }));
+    });
+  }
+
+  function execute(exportConfig, cb) {
     if (typeof exportConfig === 'string') {
       exportConfig = {
         format: 'csv',
@@ -156,16 +120,15 @@ function attachExport(client, config, xmasTree) {
         if (err) {
           return cb(err);
         }
-        fetchExport(client, config, fileId, function (err, data) {
-          if (err) {
-            return cb(err);
-          }
+        var stream = fetchExport(client, config, fileId);
+        stream.on('end', function () {
+          log.debug('Deleting export %s', exportId);
           deleteExport(xmasTree, exportId);
-          cb(null, data);
         });
+        cb(null, stream);
       });
     });
-  };
+  }
 }
 
-module.exports = attachExport;
+module.exports = attachExportMethods;

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -56,7 +56,7 @@ function buildMethod(method) {
       }
       //if (chunks.length > 0) {
         require('util').inspect(chunks, 1);
-        console.dir(chunks);
+        log.debug({chunks: chunks}, 'SOAP response');
       //}
       var newResult = Array.prototype.concat.apply([], chunks);
       cb(err, newResult);

--- a/lib/objects.js
+++ b/lib/objects.js
@@ -11,7 +11,7 @@ var objectList = [
   {name: 'communicationProfile'},
   {name: 'contact'},
   {name: 'creditBalanceAdjustment'},
-  {name: 'export', methods: ['create', 'query']},
+  {name: 'export', methods: ['create', 'delete', 'query']},
   {name: 'feature', methods: ['create', 'delete', 'update', 'query']},
   {name: 'import'},
   {name: 'Invoice'},

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "dependencies": {
     "assert-plus": "^0.1.5",
     "bunyan": "^1.3.4",
+    "csv-parser": "^1.7.0",
+    "event-stream": "^3.3.1",
+    "request": "^2.58.0",
     "soap": "^0.9.1",
     "through2": "^0.6.5",
     "vasync": "^1.6.3",


### PR DESCRIPTION
I've implemented query exports, as it's something I needed for a project. Just tossing it back to you in case you're interested.

This adds methods `z.export.asArray(exportObject[, exportConfig] , callback)` and `z.export.asStream(exportObject[, exportConfig], callback)`. They take either a ZOQL string or an export zObject as the first param and an overriding config object for the export watcher (interval, maxAttempts) as an optional second argument. I just fixed and wired up the functions that already existed to monitor an export for completion, download it from the REST API, and delete it when it has been consumed.

I'm not sure if extending `z.export` sits exactly right with me, as the `asArray` and `asStream` methods are obviously not part of the SOAP API. Nevertheless, they're specifically tied to the export zObject type, so arranging them anywhere else seemed needlessly complicated.

There are minimal changes elsewhere; mainly I changed some `console.log` invocations to use the global logger.