### PR TITLE
Added changes created by user ARENOUX that allow nested objects are p…

### DIFF
--- a/lib/xml.js
+++ b/lib/xml.js
@@ -97,13 +97,39 @@ var escapeUserFields = function(field, value) {
  * make XML tags from keys
  *
  */
+
 var xmlFromFieldList = function (zObject, ns) {
-  if (common.isString(zObject)) return zObject;
-  ns = ns || ns1;
-  return Object.keys(zObject).map(function(field) {
-    return tag(field, ns, escapeUserFields(field, zObject[field]));
-  }).join('\n');
+    if (common.isString(zObject)) return zObject;
+    return Object.keys(zObject).map(function (field) {
+        var znstype = '';
+        ns = ns || ns1;
+
+        if (field.toLowerCase() === 'rateplan' || field.toLowerCase() === 'rateplancharge') {
+            ns = ns1;
+            znstype = 'xsi:type="' + ns2 + ':' + field + '"';
+        }
+        
+        if (field.toLowerCase() == 'amendments') {
+            ns = ns1;
+        }
+        
+        if (Array.isArray(zObject[field])) {
+            return zObject[field].map(function (zObj) {
+                return tag(field, ns, xmlFromFieldList(zObj, ns2));
+            }).join('\n');
+        } else if (typeof zObject[field] === 'object') {
+            if (field.toLowerCase() === 'amendoptions'){
+                return tag(field, ns, escapeUserFields(field, xmlFromFieldList(zObject[field], ns)), znstype);   
+            }else {
+                return tag(field, ns, escapeUserFields(field, xmlFromFieldList(zObject[field], ns2)), znstype);   
+            }
+        } else {
+            return tag(field, ns, escapeUserFields(field, zObject[field]));
+        }
+
+    }).join('\n');
 };
+
 
 /**
  * Create a simple tag.
@@ -118,9 +144,17 @@ var makeActionTag = function (action, xmlObject){
   assert(action, 'required action');
   assert(xmlObject, 'required xml snippet');
   var newline = '\n';
+  var wsdlDefinitionForAction = '';
+    
+    if (action.toLowerCase() === 'amend') {
+        wsdlDefinitionForAction = ' xmlns:' + ns1 + '="http://api.zuora.com/"'
+    }
+
+    action = action + wsdlDefinitionForAction;  
+
   return '<' + ns1 + ':' + action + '>' + newline +
     xmlObject + newline +
-    '</' + ns1 + ':' + action + '>' + newline;
+    '</' + ns1 + ':' + action.replace(wsdlDefinitionForAction, '') + '>' + newline;
 };
 
 /**
@@ -141,9 +175,9 @@ var makeZobject = function (type, zObject) {
   var element = '';
   var ns = '';
 
-  if (type.toLowerCase() === 'request') {
-    element = 'requests';
-    ns = ns1;
+  if (type.toLowerCase() === 'request' || type.toLowerCase() === 'amendment') {        
+        element = 'requests';
+        ns = ns1;
   } else {
     element = 'zObjects';
     ns = ns1;

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -99,34 +99,33 @@ var escapeUserFields = function(field, value) {
  */
 
 var xmlFromFieldList = function (zObject, ns) {
-    if (common.isString(zObject)) return zObject;
+  if (common.isString(zObject)) return zObject;
     return Object.keys(zObject).map(function (field) {
-        var znstype = '';
-        ns = ns || ns1;
+      var znstype = '';
+      ns = ns || ns1;
 
-        if (field.toLowerCase() === 'rateplan' || field.toLowerCase() === 'rateplancharge') {
-            ns = ns1;
-            znstype = 'xsi:type="' + ns2 + ':' + field + '"';
-        }
+      if (field.toLowerCase() === 'rateplan' || field.toLowerCase() === 'rateplancharge') {
+        ns = ns1;
+        znstype = 'xsi:type="' + ns2 + ':' + field + '"';
+      }
         
-        if (field.toLowerCase() == 'amendments') {
-            ns = ns1;
-        }
-        
-        if (Array.isArray(zObject[field])) {
-            return zObject[field].map(function (zObj) {
-                return tag(field, ns, xmlFromFieldList(zObj, ns2));
-            }).join('\n');
-        } else if (typeof zObject[field] === 'object') {
-            if (field.toLowerCase() === 'amendoptions'){
-                return tag(field, ns, escapeUserFields(field, xmlFromFieldList(zObject[field], ns)), znstype);   
-            }else {
-                return tag(field, ns, escapeUserFields(field, xmlFromFieldList(zObject[field], ns2)), znstype);   
-            }
+      if (field.toLowerCase() == 'amendments') {
+        ns = ns1;
+      }
+
+      if (Array.isArray(zObject[field])) {
+        return zObject[field].map(function (zObj) {
+          return tag(field, ns, xmlFromFieldList(zObj, ns2));
+        }).join('\n');
+      } else if (typeof zObject[field] === 'object') {
+        if (field.toLowerCase() === 'amendoptions'){
+          return tag(field, ns, escapeUserFields(field, xmlFromFieldList(zObject[field], ns)), znstype);   
         } else {
-            return tag(field, ns, escapeUserFields(field, zObject[field]));
+          return tag(field, ns, escapeUserFields(field, xmlFromFieldList(zObject[field], ns2)), znstype);
         }
-
+      } else {
+          return tag(field, ns, escapeUserFields(field, zObject[field]));
+      }
     }).join('\n');
 };
 
@@ -145,12 +144,11 @@ var makeActionTag = function (action, xmlObject){
   assert(xmlObject, 'required xml snippet');
   var newline = '\n';
   var wsdlDefinitionForAction = '';
-    
-    if (action.toLowerCase() === 'amend') {
-        wsdlDefinitionForAction = ' xmlns:' + ns1 + '="http://api.zuora.com/"'
-    }
+  if (action.toLowerCase() === 'amend') {
+      wsdlDefinitionForAction = ' xmlns:' + ns1 + '="http://api.zuora.com/"'
+  }
 
-    action = action + wsdlDefinitionForAction;  
+  action = action + wsdlDefinitionForAction;  
 
   return '<' + ns1 + ':' + action + '>' + newline +
     xmlObject + newline +
@@ -175,9 +173,9 @@ var makeZobject = function (type, zObject) {
   var element = '';
   var ns = '';
 
-  if (type.toLowerCase() === 'request' || type.toLowerCase() === 'amendment') {        
-        element = 'requests';
-        ns = ns1;
+  if (type.toLowerCase() === 'request' || type.toLowerCase() === 'amendment') {
+    element = 'requests';
+    ns = ns1;
   } else {
     element = 'zObjects';
     ns = ns1;

--- a/lib/xml.js
+++ b/lib/xml.js
@@ -100,33 +100,33 @@ var escapeUserFields = function(field, value) {
 
 var xmlFromFieldList = function (zObject, ns) {
   if (common.isString(zObject)) return zObject;
-    return Object.keys(zObject).map(function (field) {
-      var znstype = '';
-      ns = ns || ns1;
+  return Object.keys(zObject).map(function (field) {
+    var znstype = '';
+    ns = ns || ns1;
 
-      if (field.toLowerCase() === 'rateplan' || field.toLowerCase() === 'rateplancharge') {
-        ns = ns1;
-        znstype = 'xsi:type="' + ns2 + ':' + field + '"';
-      }
+    if (field.toLowerCase() === 'rateplan' || field.toLowerCase() === 'rateplancharge') {
+    ns = ns1;
+    znstype = 'xsi:type="' + ns2 + ':' + field + '"';
+    }
         
-      if (field.toLowerCase() == 'amendments') {
-        ns = ns1;
-      }
+    if (field.toLowerCase() == 'amendments') {
+    ns = ns1;
+    }
 
-      if (Array.isArray(zObject[field])) {
-        return zObject[field].map(function (zObj) {
-          return tag(field, ns, xmlFromFieldList(zObj, ns2));
-        }).join('\n');
-      } else if (typeof zObject[field] === 'object') {
-        if (field.toLowerCase() === 'amendoptions'){
-          return tag(field, ns, escapeUserFields(field, xmlFromFieldList(zObject[field], ns)), znstype);   
-        } else {
-          return tag(field, ns, escapeUserFields(field, xmlFromFieldList(zObject[field], ns2)), znstype);
-        }
-      } else {
-          return tag(field, ns, escapeUserFields(field, zObject[field]));
-      }
+    if (Array.isArray(zObject[field])) {
+    return zObject[field].map(function (zObj) {
+        return tag(field, ns, xmlFromFieldList(zObj, ns2));
     }).join('\n');
+    } else if (typeof zObject[field] === 'object') {
+    if (field.toLowerCase() === 'amendoptions'){
+        return tag(field, ns, escapeUserFields(field, xmlFromFieldList(zObject[field], ns)), znstype);   
+    } else {
+        return tag(field, ns, escapeUserFields(field, xmlFromFieldList(zObject[field], ns2)), znstype);
+    }
+    } else {
+        return tag(field, ns, escapeUserFields(field, zObject[field]));
+    }
+  }).join('\n');
 };
 
 
@@ -145,7 +145,7 @@ var makeActionTag = function (action, xmlObject){
   var newline = '\n';
   var wsdlDefinitionForAction = '';
   if (action.toLowerCase() === 'amend') {
-      wsdlDefinitionForAction = ' xmlns:' + ns1 + '="http://api.zuora.com/"'
+    wsdlDefinitionForAction = ' xmlns:' + ns1 + '="http://api.zuora.com/"'
   }
 
   action = action + wsdlDefinitionForAction;  


### PR DESCRIPTION
…arsed as part of the payload.

Added changes to this parser so that the right zuora object types get the correct type definition, in this case ammendoptions and the action element.
Ensured that ammendment type of objects do not get a zObject element, as this is not allowed by Zuora's API.

This functionality is tested and works as expected.