### PR TITLE
Version 1.4 with new XML generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Joyent, Inc. http://www.joyent.com",
   "name": "zuora-soap",
   "description": "Client SDK and CLI for Zuora SOAP API",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "homepage": "http://github.com/joyent/node_zuora",
   "main": "zuora.js",
   "repository": {
@@ -42,7 +42,9 @@
   },
   "keywords": [
     "zuora",
-    "soap"
+    "soap",
+    "api",
+    "client"
   ],
   "private": false
 }


### PR DESCRIPTION
Request to bump version to 1.4.0 for `npm publish`. I incremented the minor version since we've added the new subscribe() and XML from @arenoux and @sgaestel.

I've published 1.4.0 to npm: https://www.npmjs.com/package/zuora-soap